### PR TITLE
fix(security): upgrade next.js and add pnpm overrides for CVEs

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -79,7 +79,7 @@
     "media-chrome": "^4.12.0",
     "moment": "^2.30.1",
     "motion": "^12.18.1",
-    "next": "14.2.3",
+    "next": "^15.3.3",
     "next-auth": "^4.24.5",
     "next-contentlayer2": "^0.5.3",
     "next-mdx-remote": "^5.0.0",
@@ -117,7 +117,7 @@
     "@types/uuid": "^9.0.8",
     "autoprefixer": "^10.4.14",
     "eslint": "^9.30.1",
-    "eslint-config-next": "14.1.0",
+    "eslint-config-next": "^15.3.3",
     "postcss": "^8.4.23",
     "tailwindcss": "^3",
     "typescript": "^5.8.3"

--- a/package.json
+++ b/package.json
@@ -35,5 +35,12 @@
   "name": "cap",
   "engines": {
     "node": "20"
+  },
+  "pnpm": {
+    "overrides": {
+      "qs": "^6.14.1",
+      "node-forge": "^1.3.1",
+      "hono": "^4.7.11"
+    }
   }
 }


### PR DESCRIPTION
## Summary
- Upgrade next.js from 14.2.3 to ^15.3.3 (CVE-2025-29927 - critical RCE)
- Upgrade eslint-config-next to ^15.3.3 for compatibility
- Add pnpm.overrides for transitive dependencies:
  - qs ^6.14.1 (prototype pollution)
  - node-forge ^1.3.1 (CVE-2022-24771)
  - hono ^4.7.11 (JWT confusion vulnerability)

## Test plan
- [ ] Build succeeds
- [ ] Dependabot alerts reduced after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded Next.js framework to version 15.3.3
  * Updated ESLint configuration to version 15.3.3
  * Added dependency resolution overrides for enhanced package management

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->